### PR TITLE
fix: npx実行エラーを修正

### DIFF
--- a/bin/openai-mcp-server.js
+++ b/bin/openai-mcp-server.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/index.js';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "OpenAI API MCP Server - MCPサーバー経由でOpenAI APIを呼び出す",
   "main": "dist/index.js",
   "type": "module",
+  "bin": {
+    "openai-mcp-server": "bin/openai-mcp-server.js"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
@@ -87,5 +90,11 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  }
+  },
+  "files": [
+    "dist/",
+    "bin/",
+    "README.md",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
## 概要
`npx .` コマンドが実行できない問題を修正しました。

## 変更内容
- `bin`ディレクトリを作成し、実行可能ファイル(`bin/openai-mcp-server.js`)を配置
- package.jsonに`bin`フィールドを追加して実行可能ファイルを登録
- `files`フィールドで配布ファイルを明示的に指定

## テスト方法
```bash
npm run build
npx .
```

上記コマンドでMCPサーバーが正常に起動することを確認。

🤖 Generated with [Claude Code](https://claude.ai/code)